### PR TITLE
.editorconfig typo correction and a recommendation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,7 @@ root = true
 [*]
 end_of_line = LF
 indent_style = tab
-indent_size = 4
 
 [.htaccess]
-indent_style = spaces
+indent_style = space
 indent_size = 2


### PR DESCRIPTION
I removed `indent_size` for `indent_style = tab` indentation so the indentation size can be customized by each programmer editing the code.

I also corrected a typo (`indent_style = spaces` should be `indent_style = space`).
