### PR TITLE
jQuery version update in Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,7 @@ module.exports = function (grunt) {
 				src: [
 					// Remove jQuery if you don't want to include the local copy
 					// in your build
-					'js/vendor/jquery-1.9.0.min.js',
+					'js/vendor/jquery-*.min.js',
 					'js/plugins/log.js',
 					'js/main.js'
 				],


### PR DESCRIPTION
jQuery version was updated to 1.9.0 in the last commit, updating it here too.

Or you can probably use a \* wildcard for the version anyways.
