### PR TITLE
Add source maps, clean /dist on deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"grunt": "0.4.x",
 		"grunt-contrib-jshint": "git://github.com/gruntjs/grunt-contrib-jshint.git",
 		"grunt-contrib-uglify": "git://github.com/gruntjs/grunt-contrib-uglify.git",
-		"grunt-contrib-concat": "git://github.com/gruntjs/grunt-contrib-concat.git",
+		"grunt-contrib-clean": "git://github.com/gruntjs/grunt-contrib-clean.git",
+		"grunt-contrib-copy": "git://github.com/gruntjs/grunt-contrib-copy.git",
 		"grunt-contrib-watch": "git://github.com/gruntjs/grunt-contrib-watch.git",
 		"grunt-contrib-sass": "git://github.com/gruntjs/grunt-contrib-sass.git",
 		"grunt-modernizr": "0.1.x"


### PR DESCRIPTION
Actually tested `contrib-copy` and `contrib-clean` and made it all work. :)

The `/dist` folder is deleted upton `grunt deploy` start, JS files are copied into the `/dist` folder, `uglify` creates the minified file and `fix-sourcemap` task fixed the source mapping until `dist-uglify` gets the right parameters implemented. 

Also fixed the `fix-sourcemap` task to being able to handle templates in filenames, like `dist/js/main-<%= pkg.version %>.min.js`.

Fixes #9.
