### PR TITLE
Move 'use strict'; up in Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
-module.exports = function (grunt) {
+'use strict';
 
-	'use strict';
+module.exports = function (grunt) {
 
 	// Project configuration.
 	grunt.initConfig({


### PR DESCRIPTION
The Node.js files can have the use strict thingy all the way up top no problem.
