### PR TITLE
prevent caching issues

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -14,6 +14,9 @@ require.config({
 
 	shim: {
 		// If you need to shim anything
-	}
+	},
+	
+	// Prevent caching issues, by adding an additional URL argument
+	urlArgs: "bust=" +  (new Date()).getTime()
 
 });


### PR DESCRIPTION
Due to caching, changes in .js modules were not recognized by the browser. With this configuration you're good during the development.
