### PR TITLE
Update to GruntJS 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "bower": "~1.2.7",
     "matchdep": "0.3.0",
-    "grunt": "0.4.x",
+    "grunt": "0.4.2",
     "grunt-concurrent": "0.4.1",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-connect": "0.5.0",


### PR DESCRIPTION
We should update to the new release.
http://gruntjs.com/blog/2013-11-21-grunt-0.4.2-released

Thought we should take care of glob and minimatch changes.
