### PR TITLE
Karma fails when running `grunt build`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('dev', ['concurrent:dev1', 'concurrent:dev2', 'pages:dev']);
 
 	// A task for deployment
-	grunt.registerTask('build', ['concurrent:build1', 'concurrent:build2', 'pages:build']);
+	grunt.registerTask('build', ['concurrent:build1', 'concurrent:build2', 'connect:test', 'karma:unit', 'pages:build']);
 
 	// A task for testing production code
 	grunt.registerTask('test', ['requirejs:compile', 'requirejs:prod', 'connect:test', 'karma:prod']);

--- a/tasks/options/concurrent.js
+++ b/tasks/options/concurrent.js
@@ -5,7 +5,7 @@
 
 module.exports = {
 	build1: ['jshint', 'modernizr', 'sass:build', 'imagemin', 'copy'],
-	build2: ['requirejs', 'connect:test', 'karma:unit'],
+	build2: ['requirejs'],
 	dev1: ['jshint', 'sass:dev', 'copy'],
 	dev2: ['requirejs']
 };


### PR DESCRIPTION
Karma currently fails when running `grunt build` with the error

> Error: Load timeout for modules: spec
>         http://requirejs.org/docs/errors.html#timeout
