### PR TITLE
Remove deprecated Grunt dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### HEAD
 
+* Use xtend instead of deprecated Grunt dependency Lodash
 * Update Grunt to 0.4.2
 * Minor updates of IE 6, 7 support
 * Removing .ir class, as it was done on HTML5 Boilerplate

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+var xtend = require('xtend');
+
 /**
  * Load configuration files for Grunt
  * @param  {string} path Path to folder with tasks
@@ -26,11 +28,9 @@ var loadConfig = function (path) {
  */
 module.exports = function (grunt) {
 
-	var config = {
+	var config = xtend({
 		pkg: require('./package')
-	};
-
-	grunt.util._.extend(config, loadConfig('./tasks/options/'));
+	}, loadConfig('./tasks/options/'));
 
 	// Load project configuration
 	grunt.initConfig(config);

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "karma-opera-launcher": "~0.1.0",
     "karma-coverage": "~0.1.0",
     "glob": "~3.2.6",
-    "grunt-contrib-clean": "~0.5.0"
+    "grunt-contrib-clean": "~0.5.0",
+    "xtend": "~2.1.1"
   },
   "keywords": []
 }


### PR DESCRIPTION
`grunt.util._` [is deprecated](http://gruntjs.com/blog/2013-11-21-grunt-0.4.2-released) and will be removed in the future. 

Seen here: https://github.com/use-init/init/blob/master/Gruntfile.js#L33

Make LoDash a dependency and use `var _ = require('lodash')` instead.
