### PR TITLE
Simplify templates markup

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,14 +1,3 @@
-		</main>
-
-		<footer>
-			<p>You can find this
-				<a href="https://github.com/use-init/init">project and its
-				documentation on github</a>,
-				<a href="https://github.com/use-init/init/issues/">file bugs</a>
-				and <a href="https://github.com/use-init/init/blob/master/LICENSE.md">read
-				the license information</a>.</p>
-		</footer>
-
 		<!-- Load scripts -->
 		@@mainjs
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -21,18 +21,3 @@
 				<a href="http://browsehappy.com/">upgrade your browser</a> to
 				improve your experience.</p>
 		<![endif]-->
-
-		<!-- Add your site or application content here -->
-		<header>
-			<h1 role="banner">init</h1>
-
-			<nav role="navigation">
-				<ul>
-					<li></li>
-					<li></li>
-					<li></li>
-				</ul>
-			</nav>
-		</header>
-
-		<main role="main">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,1 @@
 <p>Hello world! This is init.</p>
-<p>init is an HTML-framework based on HTML5 Boilerplate adding more
-	flexibility and an automation process to it. It requires you to
-	work with grunt, Sass, requireJS, bower. You can find more
-	information about the usage in the documentation found in the
-	<a href="https://github.com/use-init/init/tree/master/docs"><code>docs/</code></a>
-	folder.</p>


### PR DESCRIPTION
![init_page](https://f.cloud.github.com/assets/1313221/1819404/28940d4e-708d-11e3-9dcd-746500da735f.png)

Now index.html looks not pretty and developers before starting with init need to remove extra markup. Propose to simplify templates markup.
