### PR TITLE
Add relaxing option "eqnull" to JSHint config file.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,6 +23,7 @@
 	 * Relaxing options
 	 * See http://www.jshint.com/docs/options/#relaxing-options
 	 */
+	"eqnull": true,
 	"esnext": true,
 	"smarttabs": true,
 


### PR DESCRIPTION
:boom: … here we go.

This option suppresses warnings about == null comparisons. Such comparisons are often useful when you want to check if a variable is null or undefined (http://www.jshint.com/docs/options/#eqnull). 

See #80 for opinions about this.
