### PR TITLE
`.jshintrc`: remove `trailing` property

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,7 +15,6 @@
 	"newcap": true,
 	"noarg": true,
 	"strict": true,
-	"trailing": true,
 	"undef": true,
 	"unused": true,
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### HEAD
+* Remove `trailing` JSHint option
 * Upgrade `console.log` / `console.warn` (#112)
 * Remove timestamp logging when running Karma
 * Update to Apache Server Configs v2.7.1


### PR DESCRIPTION
The `trailing` jshint-option is deprecated: https://github.com/jshint/jshint/commit/0c0e19319b276b019d285bdfd2cfc49126abd814
