### PR TITLE
Fix broken links in docs (`html5-boilerplate.md`)

### DIFF
--- a/docs/html5-boilerplate.md
+++ b/docs/html5-boilerplate.md
@@ -7,22 +7,22 @@ for more information about [HTML5 Boilerplate](http://html5boilerplate.com).
 
 ## Getting started
 
-* [Usage](//github.com/h5bp/html5-boilerplate/blob/master/doc/usage.md) — Overview of the project contents.
-* [FAQ](//github.com/h5bp/html5-boilerplate/blob/master/doc/faq.md) — Frequently asked questions, along with their answers.
+* [Usage](//github.com/h5bp/html5-boilerplate/blob/master/dist/doc/usage.md) — Overview of the project contents.
+* [FAQ](//github.com/h5bp/html5-boilerplate/blob/master/dist/doc/faq.md) — Frequently asked questions, along with their answers.
 
 ## The core of HTML5 Boilerplate
 
-* [HTML](//github.com/h5bp/html5-boilerplate/blob/master/doc/html.md) — A guide to the default HTML.
-* [CSS](//github.com/h5bp/html5-boilerplate/blob/master/doc/css.md) — A guide to the default CSS.
-* [JavaScript](//github.com/h5bp/html5-boilerplate/blob/master/doc/js.md) — A guide to the default JavaScript.
-* [.htaccess](//github.com/h5bp/server-configs-apache/blob/master/.htaccess)
+* [HTML](//github.com/h5bp/html5-boilerplate/blob/master/dist/doc/html.md) — A guide to the default HTML.
+* [CSS](//github.com/h5bp/html5-boilerplate/blob/master/dist/doc/css.md) — A guide to the default CSS.
+* [JavaScript](//github.com/h5bp/html5-boilerplate/blob/master/dist/doc/js.md) — A guide to the default JavaScript.
+* [.htaccess](//github.com/h5bp/server-configs-apache/blob/master/dist/.htaccess)
   — All about the Apache web server configs (also see our [alternative server
   configs](//github.com/h5bp/server-configs/blob/master/README.md)).
-* [crossdomain.xml](//github.com/h5bp/html5-boilerplate/blob/master/doc/crossdomain.md) — An introduction to making use of
+* [crossdomain.xml](//github.com/h5bp/html5-boilerplate/blob/master/dist/doc/misc.md#crossdomainxml) — An introduction to making use of
   crossdomain requests.
-* [Everything else](//github.com/h5bp/html5-boilerplate/blob/master/doc/misc.md).
+* [Everything else](//github.com/h5bp/html5-boilerplate/blob/master/dist/doc/misc.md).
 
 ## Development
 
-* [Extending and customizing HTML5 Boilerplate](//github.com/h5bp/html5-boilerplate/blob/master/doc/extend.md) — Going further with
+* [Extending and customizing HTML5 Boilerplate](//github.com/h5bp/html5-boilerplate/blob/master/dist/doc/extend.md) — Going further with
   the boilerplate.


### PR DESCRIPTION
Since the docs of the `html5-boilerplate` aren't anymore in the main directory, the links in `html5-boilerplate.md` were broken.
