### PR TITLE
Removed obsolete sourcemapping option

### DIFF
--- a/grunt/options/sass.js
+++ b/grunt/options/sass.js
@@ -22,8 +22,7 @@ module.exports = {
 	dev: {
 		options: {
 			unixNewlines: true,
-			style: 'expanded',
-			sourcemap: true
+			style: 'expanded'
 		},
 
 		files: helper.sassDev


### PR DESCRIPTION
At the development parsing of Sass files, there is currently a sourcemap option given at `grunt/options/sass.js`.

```
Running "sass:dev" (sass) task
DEPRECATION WARNING: Passing --sourcemap without a value is deprecated.
Sourcemaps are now generated by default, so this flag has no effect.
```

I'd be happy to hear if there are any reasons why it is still given there. Anyway, I made a pull request about it.
