### PR TITLE
Delete unnecessary property in .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,3 @@
 {
-  "directory": "components",
-  "json": "bower.json"
+  "directory": "components"
 }


### PR DESCRIPTION
`json` property is not needed as long you are using the default `bower.json` :neckbeard:
