### PR TITLE
Use new clearfix method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Update clearfix to a more simple, leaner one
+
 ### v2.0.0
 * Update node modules
 * Add JSCS module to grunt build workflow

--- a/src/css/base/helpers.css
+++ b/src/css/base/helpers.css
@@ -53,20 +53,11 @@
  * Clearfix: contain floats
  *
  * For modern browsers
- * 1. The space content is one way to avoid an Opera bug when the
- *    `contenteditable` attribute is included anywhere else in the document.
- *    Otherwise it causes space to appear at the top and bottom of elements
- *    that receive the `clearfix` class.
- * 2. The use of `table` rather than `block` is only necessary if using
- *    `:before` to contain the top-margins of child elements.
+ * Reference: http://cssmojo.com/the-very-latest-clearfix-reloaded/
  */
 
-.clearfix:before,
-.clearfix:after {
-  content: " "; /* 1 */
-  display: table; /* 2 */
-}
-
-.clearfix:after {
+.clearfix::after {
+  content: "";
+  display: block;
   clear: both;
 }


### PR DESCRIPTION
This replaces the old clearfix method using display table
and :before pseudo elements with a more modern, leaner
way by using display block and only an :after pseudo element.

Browser support changes with that. Old Opera (Presto, <12) and
very old, unsupported IE are not supported here anymore.
